### PR TITLE
Remove ToastContainer from signup page

### DIFF
--- a/frontend/src/pages/signup.js
+++ b/frontend/src/pages/signup.js
@@ -97,7 +97,6 @@ function Signup() {
   return (
     <div className="login-card">
     <div className="signup-container">
-      <ToastContainer position="top-center" />
       <div className="login-box">
         <h1>
           Create your <span>HealthGuard Pro</span> account


### PR DESCRIPTION
fixes duplicate toast appearing after sign up. Now only 1 is visible